### PR TITLE
Bugfix passing headers with Typo3 V10

### DIFF
--- a/Classes/Service/ConnectorJson.php
+++ b/Classes/Service/ConnectorJson.php
@@ -183,9 +183,7 @@ class ConnectorJson extends ConnectorBase
         // Define the headers
         $headers = null;
         if (isset($parameters['headers']) && is_array($parameters['headers']) && count($parameters['headers']) > 0) {
-            foreach ($parameters['headers'] as $key => $header) {
-                $headers[] = $key . ': ' . $header;
-            }
+            $headers = $parameters['headers'];
         }
 
         $this->logger->info(


### PR DESCRIPTION
There is a bug with the parameters passed in header with Typo3 v10, the headers should be like this :
['Accept'] => 'application/json'
instead of this :
[0] => 'Accept: application/json'